### PR TITLE
Update hanoverd version

### DIFF
--- a/ops/newsreader-user-data.yml
+++ b/ops/newsreader-user-data.yml
@@ -44,7 +44,7 @@ coreos:
         ExecStart=/bin/mkdir -p /opt/bin
 
         ExecStart=/usr/bin/curl --location --output /opt/bin/hanoverd \
-            https://github.com/scraperwiki/hanoverd/releases/download/v0.6/hanoverd_linux_amd64
+            https://github.com/scraperwiki/hanoverd/releases/download/v0.7/hanoverd_linux_amd64
         ExecStart=/usr/bin/chmod a+x /opt/bin/hanoverd
         
         ExecStart=/bin/cp /sbin/iptables /opt/bin


### PR DESCRIPTION
For SSH key check fixes. Don't just check existence of .ssh dir:
look for SSH keys or fall back to HTTPS instead for repository cloning.