### PR TITLE
Wikinews endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ except AttributeError:
     return query_object.world_cup_example
 ```
 copy-paste the existing `cars_index()` in `views.py` and replace cars with `new_topic` throughout it, including replacing `CarsDocsCreator` with `NewTopicDocsCreator`;
-add the endpoint path name to our server routes, e.g. /new_topic and the URL of the SPARQL endpoint to `get_endpoint_url()` as it already exists for cars and world_cup, in a conditional.
+add the endpoint path name to our server routes, e.g. /new_topic and the URL of the SPARQL endpoint to `get_endpoint_credentials()` as it already exists for cars and world_cup, in a conditional. Also update `validate_api_key()`

--- a/app/make_documentation.py
+++ b/app/make_documentation.py
@@ -50,6 +50,15 @@ class DocsCreator(object):
                                       uris=["{uri_0}", "{uri_1}"],
                                       filter='{string}',
                                       datefilter='{datefilter}', output='html')
+            example_query_fragment = self._get_example_from_query(query_object)
+            if "=" in example_query_fragment:
+                example_query = ''.join([self.root_url, self.endpoint_path, '/',
+                                    self._get_example_from_query(query_object),
+                                    '&api_key=', self.user_api_key])
+            else:
+                example_query = ''.join([self.root_url, self.endpoint_path, '/',
+                                    self._get_example_from_query(query_object),
+                                    '?api_key=', self.user_api_key])
 
             function_list['queries'].append({
                 "title": query_object.query_title,
@@ -58,9 +67,7 @@ class DocsCreator(object):
                 "required_parameters": query_object.required_parameters,
                 "optional_parameters": query_object.optional_parameters,
                 "output_columns": query_object.headers,
-                "example": ''.join([self.root_url, self.endpoint_path, '/',
-                                    self._get_example_from_query(query_object),
-                                    '&api_key=', self.user_api_key]),
+                "example": example_query,
                 "sparql": query_object.query})
         return function_list
 

--- a/app/make_documentation.py
+++ b/app/make_documentation.py
@@ -101,5 +101,5 @@ class WikiNewsDocsCreator(DocsCreator):
     def _get_example_from_query(query_object):
         try:
             return query_object.wikinews_example
-        except AttributeError:
-            return query_object.world_cup_example
+        except:
+            return query_object.cars_example

--- a/app/make_documentation.py
+++ b/app/make_documentation.py
@@ -94,3 +94,12 @@ class DutchHouseDocsCreator(DocsCreator):
     @staticmethod
     def _get_example_from_query(query_object):
         return query_object.dutchhouse_example
+
+class WikiNewsDocsCreator(DocsCreator):
+    # TODO: Set self.query_ignore_list if it needs to be different.
+    @staticmethod
+    def _get_example_from_query(query_object):
+        try:
+            return query_object.wikinews_example
+        except AttributeError:
+            return query_object.world_cup_example

--- a/app/queries/actors_of_a_type.py
+++ b/app/queries/actors_of_a_type.py
@@ -17,6 +17,7 @@ class actors_of_a_type(SparqlQuery):
         self.world_cup_example = 'actors_of_a_type?uris.0=dbo:Person&filter=david'
         self.cars_example = 'actors_of_a_type?uris.0=dbo:Company&filter=motor'
         self.dutchhouse_example = 'actors_of_a_type?uris.0=dbo:Company&filter=bank'
+        self.wikinews_example = 'actors_of_a_type?uris.0=dbo:Company'
         self.query_template = ("""
 SELECT (?filterfield AS ?actor) (COUNT(DISTINCT ?event) AS ?count) ?comment
 WHERE {{

--- a/app/queries/describe_uri.py
+++ b/app/queries/describe_uri.py
@@ -17,6 +17,7 @@ class describe_uri(SparqlQuery):
         self.world_cup_example = 'describe_uri?uris.0=dbpedia:Thierry_Henry&output=json'
         self.cars_example = 'describe_uri?uris.0=dbpedia:Martin_Winterkorn&output=json'
         self.dutchhouse_example = 'describe_uri?uris.0=dbpedianl:ING_(bank)&output=json'
+        self.wikinews_example = 'describe_uri?uris.0=dbpedia:Barack_Obama&output=json'
         self.query_template = ("""
 DESCRIBE {uri_0}
                                """)

--- a/app/queries/event_details_filtered_by_actor.py
+++ b/app/queries/event_details_filtered_by_actor.py
@@ -19,6 +19,7 @@ class event_details_filtered_by_actor(SparqlQuery):
         self.world_cup_example = 'event_details_filtered_by_actor?uris.0=dbpedia:David_Beckham'
         self.cars_example = 'event_details_filtered_by_actor?uris.0=dbpedia:Martin_Winterkorn'
         self.dutchhouse_example = 'event_details_filtered_by_actor?uris.0=dbpedianl:Gerrit_Zalm'
+        self.wikinews_example = 'event_details_filtered_by_actor?uris.0=dbpedia:David_Cameron'
         self.headers = ['event', 'predicate', 'object', "object_type"]
         self.query_template = ("""
 SELECT ?event ?predicate ?object (SAMPLE(?type) AS ?object_type)

--- a/app/queries/event_label_frequency_count.py
+++ b/app/queries/event_label_frequency_count.py
@@ -18,7 +18,7 @@ class event_label_frequency_count(SparqlQuery):
         self.world_cup_example = 'event_label_frequency_count?filter=bribe+OR+bribery'
         self.cars_example = 'event_label_frequency_count?filter=takeover+OR+buyout'
         self.dutchhouse_example = 'event_label_frequency_count?filter=verkopen'
-        self.wikinews_example = 'event_label_frequency_count?filter=bribe+OR+bribery'
+        self.wikinews_example = 'event_label_frequency_count'
         self.query_template = ("""
 SELECT
 (?filterfield AS ?event_label) (COUNT(DISTINCT ?event) AS ?count)

--- a/app/queries/event_label_frequency_count.py
+++ b/app/queries/event_label_frequency_count.py
@@ -18,6 +18,7 @@ class event_label_frequency_count(SparqlQuery):
         self.world_cup_example = 'event_label_frequency_count?filter=bribe+OR+bribery'
         self.cars_example = 'event_label_frequency_count?filter=takeover+OR+buyout'
         self.dutchhouse_example = 'event_label_frequency_count?filter=verkopen'
+        self.wikinews_example = 'event_label_frequency_count?filter=bribe+OR+bribery'
         self.query_template = ("""
 SELECT
 (?filterfield AS ?event_label) (COUNT(DISTINCT ?event) AS ?count)

--- a/app/queries/event_precis.py
+++ b/app/queries/event_precis.py
@@ -17,6 +17,7 @@ class event_precis(SparqlQuery):
         self.world_cup_example = 'event_precis?uris.0=http://www.newsreader-project.eu/data/cars/2003/06/02/48RT-R260-009F-R155.xml%23ev18'
         self.cars_example = 'event_precis?uris.0=http://www.newsreader-project.eu/data/cars/2003/06/02/48RT-R260-009F-R155.xml%23ev18'
         self.dutchhouse_example = 'event_precis?uris.0=http://www.newsreader-project.eu/data/2013/10/312013/10/312013/10/31/11779884.xml%23ev7'
+        self.wikinews_example ='event_precis?uris.0=https://en.wikinews.org/wiki/Japan_Airlines_to_relist_shares%23ev16'
         self.query_template = ("""
 SELECT DISTINCT ?subject ?predicate ?object ?graph
 WHERE {{

--- a/app/queries/event_precis.py
+++ b/app/queries/event_precis.py
@@ -17,7 +17,7 @@ class event_precis(SparqlQuery):
         self.world_cup_example = 'event_precis?uris.0=http://www.newsreader-project.eu/data/cars/2003/06/02/48RT-R260-009F-R155.xml%23ev18'
         self.cars_example = 'event_precis?uris.0=http://www.newsreader-project.eu/data/cars/2003/06/02/48RT-R260-009F-R155.xml%23ev18'
         self.dutchhouse_example = 'event_precis?uris.0=http://www.newsreader-project.eu/data/2013/10/312013/10/312013/10/31/11779884.xml%23ev7'
-        self.wikinews_example ='event_precis?uris.0=https://en.wikinews.org/wiki/Japan_Airlines_to_relist_shares%23ev16'
+        self.wikinews_example ='event_precis?uris.0=http://en.wikinews.org/wiki/Vettel_becomes_youngest_Formula_One_champion%23ev27_1'
         self.query_template = ("""
 SELECT DISTINCT ?subject ?predicate ?object ?graph
 WHERE {{

--- a/app/queries/get_document.py
+++ b/app/queries/get_document.py
@@ -26,6 +26,7 @@ class get_document(CRUDQuery):
         self.world_cup_example = 'get_document?uris.0=http://news.bbc.co.uk/sport2/hi/football/gossip_and_transfers/5137822.stm'
         self.cars_example = 'get_document?uris.0=http://news.bbc.co.uk/sport2/hi/football/gossip_and_transfers/5137822.stm'
         self.dutchhouse_example = 'get_document?uris.0=http://www.newsreader-project.eu/data/2013/10/312013/10/312013/10/31/11779884.xml'
+        self.wikinews_example = 'get_document?uris.0=http://en.wikinews.org/wiki/Obama,_Romney_spar_in_first_2012_U.S._presidential_debate'
         self.query_template = ("""{uri_0}""")
         self.count_template = ("""""")
         self.endpoint_stub_url = endpoint_url
@@ -52,11 +53,11 @@ class get_document(CRUDQuery):
         """ Returns nicely parsed result of query. """
         return self.json_result
 
-    def submit_query(self):
+    def submit_query(self, username, password):
         """ Submit query to endpoint; return result. """
 
-        username = os.environ['NEWSREADER_USERNAME']
-        password = os.environ['NEWSREADER_PASSWORD']
+        #username = os.environ['NEWSREADER_USERNAME']
+        #password = os.environ['NEWSREADER_PASSWORD']
         payload = {'id': self.query}
         
         endpoint_url = self.endpoint_stub_url.format(action=self.action)

--- a/app/queries/get_document_metadata.py
+++ b/app/queries/get_document_metadata.py
@@ -19,6 +19,7 @@ class get_document_metadata(CRUDQuery):
         self.world_cup_example = 'get_document_metadata?uris.0=http://news.bbc.co.uk/sport2/hi/football/gossip_and_transfers/5137822.stm'
         self.cars_example = 'get_document_metadata?uris.0=http://www.newsreader-project.eu/data/cars/2003/01/04/47KW-0H00-01JV-737G.xml'
         self.dutchhouse_example = 'get_document_metadata?uris.0=http://www.newsreader-project.eu/data/2013/10/312013/10/312013/10/31/11779884.xml'
+        self.wikinews_example = 'get_document_metadata?uris.0=http://en.wikinews.org/wiki/Obama,_Romney_spar_in_first_2012_U.S._presidential_debate'
         self.query_template = ("""{uri_0}""")
         self.count_template = ("""""")
         self.output = 'json'

--- a/app/queries/get_mention_metadata.py
+++ b/app/queries/get_mention_metadata.py
@@ -22,6 +22,7 @@ class get_mention_metadata(CRUDQuery):
         self.world_cup_example = 'get_mention_metadata?uris.0=http%3A%2F%2Fnews.bbc.co.uk%2Fsport2%2Fhi%2Ffootball%2Fgossip_and_transfers%2F5137822.stm%23char%3D1162%2C1167%26word%3Dw220%26term%3Dt220'
         self.cars_example = 'get_mention_metadata?uris.0=http%3A%2F%2Fwww.newsreader-project.eu%2Fdata%2Fcars%2F2003%2F01%2F04%2F47KW-0H00-01JV-737G.xml%23char%3D108%2C116'
         self.dutchhouse_example = 'get_mention_metadata?uris.0=http%3A%2F%2Fwww.newsreader-project.eu%2Fdata%2F20120419%2F55FD-FNS1-F151-W2VK.xml%23char%3D1722%2C1730'
+        self.wikinews_example = 'get_mention_metadata?uris.0=http://en.wikinews.org/wiki/Obama,_Romney_spar_in_first_2012_U.S._presidential_debate%23char=1058,1067'
         self.query_template = ("""{uri_0}""")
         self.count_template = ("""""")
         self.output = 'json'

--- a/app/queries/people_sharing_event_with_a_person.py
+++ b/app/queries/people_sharing_event_with_a_person.py
@@ -18,6 +18,7 @@ class people_sharing_event_with_a_person(SparqlQuery):
         self.world_cup_example = 'people_sharing_event_with_a_person?uris.0=dbpedia:David_Beckham'
         self.cars_example = 'people_sharing_event_with_a_person?uris.0=dbpedia:Alan_Mulally'
         self.dutchhouse_example = 'people_sharing_event_with_a_person?uris.0=dbpedianl:Rijkman_Groenink'
+        self.wikinews_example = 'people_sharing_event_with_a_person?uris.0=dbpedia:Barack_Obama'
         self.query_template = ("""
 SELECT ({uri_0} AS ?actor) ?actor2
        (COUNT(DISTINCT ?evt) as ?numEvent) ?comment

--- a/app/queries/queries.py
+++ b/app/queries/queries.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 import requests
 import requests_cache
 
-requests_cache.install_cache('/tmp/requests_cache', expire_after=172800)
+requests_cache.install_cache('tmp/requests_cache', expire_after=172800)
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/app/queries/queries.py
+++ b/app/queries/queries.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 import requests
 import requests_cache
 
-requests_cache.install_cache('tmp/requests_cache', expire_after=172800)
+requests_cache.install_cache('/tmp/requests_cache', expire_after=172800)
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/app/queries/situation_graph.py
+++ b/app/queries/situation_graph.py
@@ -18,6 +18,7 @@ class situation_graph(SparqlQuery):
         self.world_cup_example = 'situation_graph?uris.0=http://www.newsreader-project.eu/data/cars/2003/06/02/48RT-R260-009F-R155.xml%23ev18'
         self.cars_example = 'situation_graph?uris.0=http://www.newsreader-project.eu/data/cars/2003/06/02/48RT-R260-009F-R155.xml%23ev18'
         self.dutchhouse_example = 'situation_graph?uris.0=http://www.newsreader-project.eu/data/20100522/7YH5-PWH1-2S3X-Y306.xml%23ev3'
+        self.wikinews_example = 'situation_graph?uris.0=http://en.wikinews.org/wiki/Fifteen_medals_awarded_on_London_Paralympics_fourth_night_of_track_and_field%23ev50_6'
         self.query_template = ("""
 SELECT ?timeline ?subject ?predicate ?object
 WHERE {{

--- a/app/queries/summary_of_events_with_actor.py
+++ b/app/queries/summary_of_events_with_actor.py
@@ -19,6 +19,7 @@ class summary_of_events_with_actor(SparqlQuery):
         self.world_cup_example = 'summary_of_events_with_actor?uris.0=dbpedia:Thierry_Henry'
         self.cars_example = 'summary_of_events_with_actor?uris.0=dbpedia:Alan_Mulally'
         self.dutchhouse_example = 'summary_of_events_with_actor?uris.0=dbpedianl:Rijkman_Groenink'
+        self.wikinews_example = 'summary_of_events_with_actor?uris.0=dbpedia:Barack_Obama'
         self.query_template = ("""
 SELECT ?event (COUNT(*) AS ?event_size) ?datetime ?event_label
 WHERE {{

--- a/app/queries/summary_of_events_with_actor_type.py
+++ b/app/queries/summary_of_events_with_actor_type.py
@@ -19,7 +19,7 @@ class summary_of_events_with_actor_type(SparqlQuery):
         self.world_cup_example = 'summary_of_events_with_actor_type?datefilter=2010-01&uris.0=dbo:GolfPlayer'
         self.cars_example = 'summary_of_events_with_actor_type?datefilter=2010-01&uris.0=dbo:Company'
         self.dutchhouse_example = 'summary_of_events_with_actor_type?datefilter=2010-01&uris.0=dbo:Company'
-
+        self.wikinews_example = 'summary_of_events_with_actor_type?datefilter=2010-01&uris.0=dbo:Company'
         self.query_template = ("""
 SELECT ?event (COUNT (*) AS ?event_size) ?datetime ?actor
 WHERE {{

--- a/app/queries/summary_of_events_with_two_actors.py
+++ b/app/queries/summary_of_events_with_two_actors.py
@@ -19,6 +19,7 @@ class summary_of_events_with_two_actors(SparqlQuery):
         self.world_cup_example = 'summary_of_events_with_two_actors?uris.0=dbpedia:David_Beckham&uris.1=dbpedia:Sepp_Blatter'
         self.cars_example = 'summary_of_events_with_two_actors?uris.0=dbpedia:Alan_Mulally&uris.1=dbpedia:William_Clay_Ford,_Jr.'
         self.dutchhouse_example = 'summary_of_events_with_two_actors?uris.0=dbpedianl:Rijkman_Groenink&uris.1=dbpedianl:Mark_Rietman'
+        self.wikinews_example = 'summary_of_events_with_two_actors?uris.0=dbpedia:Barack_Obama&uris.1=dbpedia:Mitt_Romney'
         self.query_template = ("""
 SELECT ?event (COUNT(*) AS ?event_size) ?datetime ?event_label
 WHERE {{

--- a/app/queries/types_of_actors.py
+++ b/app/queries/types_of_actors.py
@@ -20,6 +20,7 @@ class types_of_actors(SparqlQuery):
         self.world_cup_example = 'types_of_actors?filter=player'
         self.cars_example = 'types_of_actors?filter=driver'
         self.dutchhouse_example = 'types_of_actors'
+        self.wikinews_example = 'types_of_actors?filter=player'
         self.query_template = ("""
 SELECT ?type (COUNT(DISTINCT ?a) AS ?count)
 WHERE {{

--- a/app/views.py
+++ b/app/views.py
@@ -217,8 +217,12 @@ def final_page_exceeded(count, page_number):
 
 
 def parse_get_mention_metadata(query_string):
-    parsed_query = {"output":"html", "uris":[query_string[7:]]}
-    print parsed_query
+    # Remove preamble
+    query_tmp = query_string.replace("uris.0=","")
+    # Remove api_key
+    index = query_tmp.find("api_key")
+    query_tmp = query_tmp[:index-1]
+    parsed_query = {"output":"html", "uris":[query_tmp]}
     return parsed_query
 
 def assemble_query(query_to_use, query_args, page):

--- a/app/views.py
+++ b/app/views.py
@@ -43,7 +43,7 @@ def validate_api_key(api_key, endpoint):
     validated = False
     if endpoint == 'dutchhouse' and api_key in private_api_keys:
         validated = True
-    elif endpoint in ['cars', 'worldcup'] and api_key in public_api_keys:
+    elif endpoint in ['cars', 'worldcup', 'wikinews'] and api_key in public_api_keys:
         validated = True
     return validated
 
@@ -84,6 +84,15 @@ def worldcup_index():
     function_list = make_documentation.WorldCupDocsCreator(root_url,
                                                            user_api_key,
                                                            endpoint_path).make_docs()
+    return index(function_list)
+
+@app.route('/wikinews')
+def wikinews_index():
+    root_url = get_root_url()
+    endpoint_path = '/wikinews'
+    user_api_key = request.args.get('api_key')
+    function_list = make_documentation.CarsDocsCreator(root_url, user_api_key,
+                                                       endpoint_path).make_docs()
     return index(function_list)
 
 @app.route('/dutchhouse')
@@ -137,7 +146,11 @@ def get_endpoint_credentials(api_endpoint):
                '/nwr/dutchhouse-v2/{action}')
         username = os.environ.get('NEWSREADER_PRIVATE_USERNAME')
         password = os.environ.get('NEWSREADER_PRIVATE_PASSWORD')
-
+    elif api_endpoint == 'wikinews':
+        url = ('https://knowledgestore2.fbk.eu'
+               '/nwr/wikinews/{action}')
+        username = ''
+        password = ''
     return Credentials(url, username, password)
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -91,7 +91,7 @@ def wikinews_index():
     root_url = get_root_url()
     endpoint_path = '/wikinews'
     user_api_key = request.args.get('api_key')
-    function_list = make_documentation.CarsDocsCreator(root_url, user_api_key,
+    function_list = make_documentation.WikiNewsDocsCreator(root_url, user_api_key,
                                                        endpoint_path).make_docs()
     return index(function_list)
 


### PR DESCRIPTION
Add a new wikinews endpoint. Fairly straightforward, it also fixes a bug whereby an example query was mangled if it had no parameters. (issue #16)

Also the `get_mention_metadata` has been fixed, likely it was broken since introducing the `api_key`. (issue #33)

