### PR TITLE
Eso and Framenet frequency count queries

### DIFF
--- a/app/queries/__init__.py
+++ b/app/queries/__init__.py
@@ -31,7 +31,8 @@ from .event_label_frequency_count import event_label_frequency_count
 
 from .summary_of_events_with_framenet import summary_of_events_with_framenet
 from .summary_of_events_with_eso import summary_of_events_with_eso
-#from .framenet_frequency_count import framenet_frequency_count
+from .framenet_frequency_count import framenet_frequency_count
+from .eso_frequency_count import eso_frequency_count
 
 from .get_document_metadata import get_document_metadata
 from .get_mention_metadata import get_mention_metadata

--- a/app/queries/eso_frequency_count.py
+++ b/app/queries/eso_frequency_count.py
@@ -38,14 +38,13 @@ OFFSET {offset}
 
         self.count_template = ("""
 SELECT
-(COUNT (?eso) AS ?count)
+(COUNT (DISTINCT ?eso) AS ?count)
 WHERE {{
 ?event a sem:Event . 
 ?event a ?filterfield . 
 FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/domain-ontology")) .
 BIND (?filterfield AS ?eso) .
 }}
-GROUP BY ?eso
                                """)
 
         self.jinja_template = 'table.html'

--- a/app/queries/eso_frequency_count.py
+++ b/app/queries/eso_frequency_count.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# encoding: utf-8
+from __future__ import unicode_literals
+
+from queries import SparqlQuery
+
+class eso_frequency_count(SparqlQuery):
+
+    """ Get the frequency of eso terms across all events
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(eso_frequency_count, self).__init__(*args, **kwargs)
+        self.query_title = 'Frequency of eso types in events'
+        self.description = ("eso provides an indication of the character of"
+            " an event, as determined by semantic 'frames'.**This query is very slow"
+            " and will timeout the server, contents are available as a file**") 
+        self.url = 'eso_frequency_count'
+        self.world_cup_example = 'eso_frequency_count'
+        self.cars_example = 'eso_frequency_count'
+        self.dutchhouse_example = 'eso_frequency_count'
+        self.wikinews_example = 'eso_frequency_count'
+        self.query_template = ("""
+SELECT
+?eso (count (?eso) AS ?count)
+WHERE {{
+?event a sem:Event . 
+?event a ?filterfield . 
+FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/domain-ontology")) .
+BIND (?filterfield AS ?eso) .
+}}
+GROUP BY ?eso
+ORDER by desc(?count)
+LIMIT {limit}
+OFFSET {offset}
+                               """)
+
+        self.count_template = ("""
+SELECT
+(COUNT (?eso) AS ?count)
+WHERE {{
+?event a sem:Event . 
+?event a ?filterfield . 
+FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/domain-ontology")) .
+BIND (?filterfield AS ?eso) .
+}}
+GROUP BY ?eso
+                               """)
+
+        self.jinja_template = 'table.html'
+        self.headers = ['eso', 'count']
+
+        self.required_parameters = []
+        self.optional_parameters = ["output", "filter"]
+        self.number_of_uris_required = 0
+
+        self.query = self._build_query()

--- a/app/queries/framenet_frequency_count.py
+++ b/app/queries/framenet_frequency_count.py
@@ -20,13 +20,14 @@ class framenet_frequency_count(SparqlQuery):
         self.world_cup_example = 'framenet_frequency_count'
         self.cars_example = 'framenet_frequency_count'
         self.dutchhouse_example = 'framenet_frequency_count'
+        self.wikinews_example = 'framenet_frequency_count'
         self.query_template = ("""
 SELECT
 ?frame (count (?frame) AS ?count)
 WHERE {{
 ?event a sem:Event . 
 ?event a ?filterfield . 
-FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/framenet/")) .
+FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/ontologies/framenet/")) .
 BIND (?filterfield AS ?frame) .
 }}
 GROUP BY ?frame
@@ -41,7 +42,7 @@ SELECT
 WHERE {{
 ?event a sem:Event . 
 ?event a ?filterfield . 
-FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/framenet/")) .
+FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/ontologies/framenet/")) .
 BIND (?filterfield AS ?frame) .
 }}
 GROUP BY ?frame

--- a/app/queries/framenet_frequency_count.py
+++ b/app/queries/framenet_frequency_count.py
@@ -38,14 +38,13 @@ OFFSET {offset}
 
         self.count_template = ("""
 SELECT
-(COUNT (?frame) AS ?count)
+(COUNT (DISTINCT ?frame) AS ?count)
 WHERE {{
 ?event a sem:Event . 
 ?event a ?filterfield . 
 FILTER(STRSTARTS(STR(?filterfield), "http://www.newsreader-project.eu/ontologies/framenet/")) .
 BIND (?filterfield AS ?frame) .
 }}
-GROUP BY ?frame
                                """)
 
         self.jinja_template = 'table.html'

--- a/app/templates/table.html
+++ b/app/templates/table.html
@@ -53,8 +53,8 @@
               <td><a href="{{ result[header] }}">{{ result[header].replace('http://purl.org/dc/terms/', 'dct:') }}</td>
                 {% elif result[header] != None and result[header].startswith('http://www.newsreader-project.eu/domain-ontology') %}
               <td><a href="{{ result[header] }}">{{ result[header].replace('http://www.newsreader-project.eu/domain-ontology#', 'eso:') }}</td>
-                {% elif result[header] != None and result[header].startswith('http://www.newsreader-project.eu/framenet') %}
-              <td><a href="{{ result[header] }}">{{ result[header].replace('http://www.newsreader-project.eu/framenet', 'framenet:') }}</td>
+                {% elif result[header] != None and result[header].startswith('http://www.newsreader-project.eu/ontologies/framenet/') %}
+              <td><a href="{{ result[header] }}">{{ result[header].replace('http://www.newsreader-project.eu/ontologies/framenet/', 'framenet:') }}</td>
                 {% elif result[header] != None and result[header].startswith('http://groundedannotationframework.org/gaf#') %}
               <td><a href="{{ result[header] }}">{{ result[header].replace('http://groundedannotationframework.org/gaf#', 'gaf:') }}</td>
                 {% elif result[header] != None and result[header].startswith('http://www.w3.org/1999/02/22-rdf-syntax-ns#') %}


### PR DESCRIPTION
This re-introduces and repairs the Framenet frequency count query, previously disabled for poor performance it runs acceptably on the `wikinews` endpoint. A similar query for the eso ontology is added.

Resolves #40 