### PR TITLE
Revert "Temporary fix for endpoint being down"

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -133,7 +133,7 @@ def get_endpoint_credentials(api_endpoint):
     """ Take name of API endpoint as string; return KS SPARQL URL. """
     Credentials = namedtuple("Credentials", "url username password")
     # Cars as default endpoint
-    url = ('http://www.airpedia.org/alessio/ks/{action}')
+    url = ('https://knowledgestore2.fbk.eu/nwr/cars-hackathon/{action}')
     username = os.environ.get('NEWSREADER_PUBLIC_USERNAME')
     password = os.environ.get('NEWSREADER_PUBLIC_PASSWORD')
 


### PR DESCRIPTION
This reverts commit 58db6194632e437aa33ab634de0c2fc758dd21e0.

We're restoring the FBK endpoint rather than using the temporary one.